### PR TITLE
Printing fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!-- badges: start -->
 <!-- badges: end -->
 
-A small shiny app to live translate C++ code to R. 
+A small shiny app to live translate C++ code to R.
 
 Deploy at your own risk as user input code is evaluated.
 
@@ -23,10 +23,6 @@ remotes::install_github("dirkschumacher/armacmp")
 # Launch the translator application.
 shiny::runGitHub("dirkschumacher/armacmp-shiny")
 ```
-
-## Author
-
-[Dirk Schumacher](http://www.dirk-schumacher.net)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -23,3 +23,11 @@ remotes::install_github("dirkschumacher/armacmp")
 # Launch the translator application.
 shiny::runGitHub("dirkschumacher/armacmp-shiny")
 ```
+
+## Author
+
+[Dirk Schumacher](http://www.dirk-schumacher.net)
+
+## License
+
+MIT 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,23 @@
 <!-- badges: start -->
 <!-- badges: end -->
 
-A small shiny app to live translate C++ code to R.
+A small shiny app to live translate C++ code to R. 
 
 Deploy at your own risk as user input code is evaluated.
 
 ![demo](docs/armacmp.gif)
+
+## Usage
+
+To obtain a copy for your local computer, please use: 
+
+```r
+# Install required packages
+install.packages(c("shiny", "remotes"))
+
+# Install armacmp
+remotes::install_github("dirkschumacher/armacmp")
+
+# Launch the translator application.
+shiny::runGitHub("dirkschumacher/armacmp-shiny")
+```

--- a/app.R
+++ b/app.R
@@ -21,14 +21,14 @@ p {
 }
       "))
   ),
-  titlePanel("Armacmp compiler tools"),
+  titlePanel("Translate and Compile R code into C++"),
   fluidRow(
     column(
       12,
       p(
-        "Use the R package ",
+        "R code is translated into C++ using the",
         a("armacmp", href = "https://github.com/dirkschumacher/armacmp"),
-        " to compile R to C++."
+        " R package."
       )
     )
   ),

--- a/app.R
+++ b/app.R
@@ -53,7 +53,7 @@ p {
   ),
   fluidRow(
     column(12,
-           h4("Compilation Embedded in R"),
+           h4("C++ Code for use in R"),
            aceEditor(
              outputId = "rcpp_code_text",
              theme = "tomorrow_night_blue",

--- a/app.R
+++ b/app.R
@@ -33,19 +33,23 @@ p {
     )
   ),
   fluidRow(
-    column(6, aceEditor(
-      outputId = "r_code",
-      theme = "tomorrow_night_blue",
-      mode = "r",
-      value = initial_fun
-    )),
-    column(6, aceEditor(
-      outputId = "cpp_code",
-      theme = "tomorrow_night_blue",
-      mode = "c_cpp",
-      readOnly = TRUE,
-      value = initial_fun
-    ))
+    column(6,
+           h4("R Code"),
+           aceEditor(
+             outputId = "r_code",
+             theme = "tomorrow_night_blue",
+             mode = "r",
+             value = initial_fun
+           )),
+    column(6,
+           h4("Translated to C++"),
+           aceEditor(
+             outputId = "cpp_code",
+             theme = "tomorrow_night_blue",
+             mode = "c_cpp",
+             readOnly = TRUE,
+             value = initial_fun
+           ))
   ),
   fluidRow(
     column(12, aceEditor(

--- a/app.R
+++ b/app.R
@@ -82,11 +82,10 @@ server <- function(input, output, session) {
   rcpp_code <- reactive({
     req(is.character(cpp_code()))
 
-    header = 'Rcpp::cppFunction("\n'
-    footer = '", depends = "RcppArmadillo", plugins = "cpp11")'
+    header <- 'Rcpp::cppFunction("\n'
+    footer <- '", depends = "RcppArmadillo", plugins = "cpp11")'
 
     paste0(header, paste0(cpp_code(), collapse = "\n"), footer, collapse = "\n")
-
   })
 
   observe({

--- a/app.R
+++ b/app.R
@@ -72,14 +72,15 @@ server <- function(input, output, session) {
       "[compiler error]"
     })
   })
+
   rcpp_code <- reactive({
     req(is.character(cpp_code()))
-    paste0(deparse(bquote(
-      Rcpp::cppFunction(.(cpp_code()),
-        depends = "RcppArmadillo",
-        plugins = "cpp11"
-      )
-    )), collapse = "\n")
+
+    header = 'Rcpp::cppFunction("\n'
+    footer = '", depends = "RcppArmadillo", plugins = "cpp11")'
+
+    paste0(header, paste0(cpp_code(), collapse = "\n"), footer, collapse = "\n")
+
   })
 
   observe({

--- a/app.R
+++ b/app.R
@@ -52,13 +52,15 @@ p {
            ))
   ),
   fluidRow(
-    column(12, aceEditor(
-      outputId = "rcpp_code_text",
-      theme = "tomorrow_night_blue",
-      mode = "r",
-      readOnly = TRUE,
-      value = initial_fun
-    ))
+    column(12,
+           h4("Compilation Embedded in R"),
+           aceEditor(
+             outputId = "rcpp_code_text",
+             theme = "tomorrow_night_blue",
+             mode = "r",
+             readOnly = TRUE,
+             value = initial_fun
+           ))
   )
 )
 

--- a/app.R
+++ b/app.R
@@ -13,7 +13,7 @@ ui <- fluidPage(
 body {
   background-color: black;
 }
-h2 {
+h2,h4 {
   color: white;
 }
 p {


### PR DESCRIPTION
Follow up from the comment in https://github.com/dirkschumacher/armacmp-shiny/commit/2173cb1d3f0a3b79cfb8cf110bfa9ba295f55e81#r34907078

This PR fixes printing of the Compilation to be used with _R_. Moreover, the interface has been labeled to better explain what is happening. 

![Screen Shot 2019-08-31 at 7 52 00 PM](https://user-images.githubusercontent.com/833642/64070568-da9d2280-cc28-11e9-88f0-8bdb86c3dc5e.png)

In addition, I added instructions for how to obtain the app into the `README.md`.
